### PR TITLE
Added optional chaining operator (?.) so that 'childNodes' of non-exi…

### DIFF
--- a/assets/js/theme/widget-services/sticker-widget/sticker-widget-html.js
+++ b/assets/js/theme/widget-services/sticker-widget/sticker-widget-html.js
@@ -1,10 +1,10 @@
 import SELECTORS from '../../product/widget-base-code/sticker-dom-selectors';
 
 export var hiddenElements = {
-    hiddenWidth: document.querySelectorAll('[data-product-attribute="input-number"]')[0].childNodes[3],
-    hiddenHeight: document.querySelectorAll('[data-product-attribute="input-number"]')[1].childNodes[3],
-    hiddenQuantity: document.querySelectorAll('[data-product-attribute="input-number"]')[2].childNodes[3],
-    hiddenResult: document.querySelectorAll('[data-product-attribute="input-number"]')[3].childNodes[3]
+    hiddenWidth: document.querySelectorAll('[data-product-attribute="input-number"]')[0]?.childNodes[3],
+    hiddenHeight: document.querySelectorAll('[data-product-attribute="input-number"]')[1]?.childNodes[3],
+    hiddenQuantity: document.querySelectorAll('[data-product-attribute="input-number"]')[2]?.childNodes[3],
+    hiddenResult: document.querySelectorAll('[data-product-attribute="input-number"]')[3]?.childNodes[3]
 }
 
 


### PR DESCRIPTION
Issue: 
The addition of the 'bulk custom sticker (widget)' code introduced a bug which caused the 'sticker designer' product code to break.

Errors: 
When loading the sticker-builder product page the error is received in the browser:
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'childNodes')
    at ./assets/js/theme/widget-services/sticker-widget/sticker-widget-html.js (sticker-widget-html.js:4:89)

Resolution:
Added optional chaining operator (?.) so that 'childNodes' of non-existent elements are not requested during execution.

The 'sticker-widget-html.js' file is imported ultimately to the 'product.js' file which runs on any product page. Instead of using the default product page template, a custom template should be created for the 'bulk custom sticker' products and an associated JS file where related JS imports should reside. This would allow segregation of code execution between different custom products.
