### PR TITLE
Automates setting the exported excalidraw svg to the product file inp…

### DIFF
--- a/assets/js/react-components/CustomExcalidrawDesigner.js
+++ b/assets/js/react-components/CustomExcalidrawDesigner.js
@@ -22,22 +22,15 @@ export default function CustomExcalidrawDesigner() {
 
   const reviewDesign = async () => {
     const api = excalidrawRef.current;
-
     if (!api) return;
-
-    const curStickerSvg = await api.exportSticker();
-
-    const stickerStr = new XMLSerializer().serializeToString(curStickerSvg);
-    const stickerEncoded = 'data:image/svg+xml;base64,' + window.btoa(stickerStr);
-
-    localStorage.setItem('excalidrawImg', stickerEncoded);
-
-    const designerReviewEvent = new CustomEvent(
-      'openDesignerReviewModal',
-      { detail: stickerEncoded }
+    
+    const excalidrawSvg = await api.exportSticker();
+    const reviewDesignEvent = new CustomEvent(
+      'reviewDesign',
+      { detail: excalidrawSvg }
     );
 
-    window.dispatchEvent(designerReviewEvent);
+    window.dispatchEvent(reviewDesignEvent);
   }
 
   return (

--- a/assets/js/theme/custom/designer-product/sticker-designer.js
+++ b/assets/js/theme/custom/designer-product/sticker-designer.js
@@ -6,17 +6,21 @@ import { defaultModal } from '../../global/modal.js';
 import { api } from '@bigcommerce/stencil-utils';
 import DesignerApiClient from '../util/DesignerApiClient.js';
 import parseDimensions from '../util/parseDimensions.js';
-import chunkString from '../util/chunk-string.js'
 import '@bumperactive/excalidraw/index.css';
+import appendSvgToParent from '../util/append-svg-to-parent.js';
+import generateUniqueFilename from '../util/generate-unique-filename.js';
 
 const excalidrawDesignerSelector = '#excalidraw-designer';
 const productViewSelector = '#productViewDesigner';
 const modalEditBtnSelector = '[data-designer-modal-edit]';
 const modalContinueBtnSelector = '[data-designer-modal-continue]';
-const modalImgSelector = '#designer-review-modal img';
-const productViewImgSelector = '.productView-large-image';
-const addToCartFormSelector = '[data-cart-item-add]';
+const modalImgWrapperSelector = '#designer-review-excalidraw-img-wrapper';
+const productViewDesignImgWrapper = '#productView-design-image-wrapper';
 const optionFormFields = '#designer-meta-fields .form-field';
+const inputFileSelector = '.form-file';
+
+const DESIGN_FILENAME_PREFIX = 'design';
+const DESIGN_FILE_EXTENSION = 'svg';
 
 export default class StickerDesigner extends PageManager {
   constructor(context) {
@@ -28,14 +32,18 @@ export default class StickerDesigner extends PageManager {
     this.$excalidrawContainer = $(excalidrawDesignerSelector);
     this.$productViewDesigner = $(productViewSelector);
     this.$optionFormFields = $(optionFormFields);
-    this.designerImgDataUrl = null;
+    this.$fileInput = this.findFileInput(this.$optionFormFields);
     this.modal = null;
+    this.excalidrawSvg = null
 
+    this.initializePageContent();
+  }
+
+  initializePageContent() {
     this.$productViewDesigner.hide();
     const canvasDimensions = parseDimensions(this.context.canvasExportDimensions);
     this.renderReactComponent(this.$excalidrawContainer[0], CustomExcalidrawDesigner, {canvasDimensions: canvasDimensions});
     this.bindEvents();
-
   }
 
   parseDimensions(dimensions) {
@@ -65,25 +73,24 @@ export default class StickerDesigner extends PageManager {
   }
 
   bindExcalidrawDesignerEvents() {
-    window.addEventListener('openDesignerReviewModal', (event) => {
-      const excalidrawImgDataUrl = event.detail;
-      this.openDesignerModal(excalidrawImgDataUrl);
-      this.updateImageSource(productViewImgSelector, excalidrawImgDataUrl);
+    window.addEventListener('reviewDesign', (event) => {
+      this.excalidrawSvg = event.detail; // exported SVG element from Excalidraw
+      const excalidrawSvgString = new XMLSerializer().serializeToString(this.excalidrawSvg); // convert svg element to string
+      localStorage.setItem('excalidrawSvgString', excalidrawSvgString);
+
+      this.openDesignerModal();
     })
   }
 
-  openDesignerModal(designerImgDataUrl) {
-    this.designerImgDataUrl = designerImgDataUrl;
+  openDesignerModal() {
     this.modal = defaultModal();
 
     // get modal template code
-    api.getPage('/sticker-designer', {template: 'products/modals/designerReview'}, (err, content) => {
-      if (err) {
-          return this.modal.updateContent(this.context.previewError);
-      }
-
-      this.modal.updateContent(content);
-      this.updateImageSource(modalImgSelector, designerImgDataUrl);
+    api.getPage('/sticker-designer', {template: 'products/modals/designerReview'}, async (err, content) => {
+      if (err) return this.modal.updateContent(this.context.previewError);
+      
+      await this.modal.updateContent(content);
+      appendSvgToParent(this.excalidrawSvg, modalImgWrapperSelector);
       this.bindDesignerModalEvents();
     });
     this.modal.open();
@@ -102,43 +109,47 @@ export default class StickerDesigner extends PageManager {
       if ($(event.target).is(modalContinueBtnSelector)) {
         this.$excalidrawContainer.hide()
         this.$productViewDesigner.show();
+        appendSvgToParent(this.excalidrawSvg, productViewDesignImgWrapper);
         this.modal.close();
-        this.bindProductViewDesignerEvents();
-        this.handleImageUrlFields();
+        this.setSvgToFileInputField();
       }
     });
   }
 
-  updateImageSource(selector, imgDataUrl) {
-    const $element = $(selector);
-    if ($element.length) {
-        $element.attr('src', imgDataUrl);
+  setSvgToFileInputField() {
+    if (!this.$fileInput) {
+      console.log("A file input form field could not be found.")
+      return;
     }
+
+    if (!this.excalidrawSvg) {
+      console.log("Missing exported Excalidraw SVG")
+      return;
+    }
+
+    const fileContent = localStorage.getItem('excalidrawSvgString');
+    const filename = generateUniqueFilename(DESIGN_FILE_EXTENSION, DESIGN_FILENAME_PREFIX);
+    const file = new File([fileContent], filename);
+
+    // Create a data transfer object. Similar to what you get from a file 'drag and drop' event as `event.dataTransfer`
+    const dataTransfer = new DataTransfer();
+    // Add your file to the file list of the object
+    dataTransfer.items.add(file);
+    // Save the file list to a new variable
+    const fileList = dataTransfer.files;
+    // Set your input `files` to the file list
+    this.$fileInput[0].files = fileList; 
   }
 
-  bindProductViewDesignerEvents() {
-    this.$addToCartForm = $(addToCartFormSelector);
-    this.$addToCartForm.on('submit', () => {
-    })
-  }
-
-  handleImageUrlFields() {
-    const imgDataUrlChunks = chunkString(this.designerImgDataUrl, 60000);
-
-    this.$optionFormFields.each((index, field) => {
-      const $field = $(field);
-      const $fieldLabel = $field.find('label');
-      const $fieldInput = $field.find('input');
-     
-      if ( $fieldLabel.text().toLowerCase().includes('image url') ) {
-        $field.hide();
-
-        if (imgDataUrlChunks[0]) {
-          $fieldInput.val(imgDataUrlChunks.shift());
+  findFileInput($formFields) {
+    for (const field of $formFields) {
+        const $fileInput = $(field).children(inputFileSelector);
+        if ($fileInput.length > 0) { // Check if there are any matching elements
+            return $fileInput;
         }
-      }
-    })
-  }
-  
-}
+    }
 
+    console.log("A file input form field could not be found.");
+    return null;
+  }
+}

--- a/assets/js/theme/custom/util/append-svg-to-parent.js
+++ b/assets/js/theme/custom/util/append-svg-to-parent.js
@@ -1,0 +1,24 @@
+export default function appendSvgToParent(svg, parent) {
+  // Validate svg
+  if (svg.nodeName.toLowerCase() !== "svg") {
+      console.error("Provided element is not a valid SVG element.");
+      return;
+  }
+
+  // Determine the parent element
+  let parentElement;
+  if (typeof parent === "string") {
+      parentElement = document.querySelector(parent);
+      if (!parentElement) {
+          console.error("Target element not found for the provided selector:", parent);
+          return;
+      }
+  } else if (parent instanceof HTMLElement) {
+      parentElement = parent;
+  } else {
+      console.error("Provided parent is neither a valid selector nor a DOM node.");
+      return;
+  }
+
+  return parentElement.appendChild(svg);
+}

--- a/assets/js/theme/custom/util/generate-unique-filename.js
+++ b/assets/js/theme/custom/util/generate-unique-filename.js
@@ -1,0 +1,27 @@
+export default function generateUniqueFilename(extension, prefix = '') {
+  // Get the current date and time in local Central Time
+  const now = new Date();
+  const centralTimeOffset = -6 * 60; // CST is UTC-6
+  const isDST = new Date().toLocaleTimeString('en-us', { timeZoneName: 'short' }).includes('CDT');
+  const centralOffset = centralTimeOffset + (isDST ? 60 : 0); // Adjust for daylight saving time if necessary
+  
+  const centralTime = new Date(now.getTime() + (now.getTimezoneOffset() + centralOffset) * 60000);
+  
+  // Format the datetime string as 'YYYY-MM-DD_HH.mm.ss.sss'
+  const year = centralTime.getFullYear();
+  const month = String(centralTime.getMonth() + 1).padStart(2, '0');
+  const day = String(centralTime.getDate()).padStart(2, '0');
+  const hours = String(centralTime.getHours()).padStart(2, '0');
+  const minutes = String(centralTime.getMinutes()).padStart(2, '0');
+  const seconds = String(centralTime.getSeconds()).padStart(2, '0');
+  const milliseconds = String(centralTime.getMilliseconds()).padStart(3, '0');
+  
+  const datetimeString = `${year}-${month}-${day}_${hours}.${minutes}.${seconds}.${milliseconds}`;
+  
+  // Combine the prefix and datetime string to generate the filename
+  let filename = `${datetimeString}.${extension}`
+  if (prefix) {
+    filename = `${prefix}_${filename}`;
+  }
+  return filename;
+}

--- a/assets/scss/components/custom/modal/_designerReviewModal.scss
+++ b/assets/scss/components/custom/modal/_designerReviewModal.scss
@@ -14,7 +14,7 @@
     padding: $reveal-modal-padding;
 }
 
-.designer-review-modal img {
+.designer-review-modal svg {
     display: block;    
     width: 100%;          
     height: auto;           

--- a/assets/scss/components/custom/product/_productViewDesigner.scss
+++ b/assets/scss/components/custom/product/_productViewDesigner.scss
@@ -3,23 +3,9 @@
 // =============================================================================
 
 .productViewDesigner .productView-details {
-    float: none;
-    
-    @include breakpoint("medium") {
-        margin: auto;
-    }
-}
-
-.productView-image-section {
-    width: 100%; 
-    max-width: 600px; 
-    margin: 0 auto; 
-    margin-bottom: 20px; 
-}
-
-.productView-large-image {
     width: 100%;
-    height: auto;
-    display: block; 
-    object-fit: contain;
+}
+
+#productView-design-image-wrapper {
+    display: flex;
 }

--- a/templates/components/products/modals/designerReview.html
+++ b/templates/components/products/modals/designerReview.html
@@ -4,9 +4,7 @@
   </div>
 
   <div class="modal-body">
-    <div class="designer-review-excalidraw-img-container" id="designer-review-excalidraw-img-container">
-      <img class="designer-review-excalidraw-img" src="" alt="product design" />
-    </div>
+    <div class="designer-review-excalidraw-img-wrapper" id="designer-review-excalidraw-img-wrapper"></div>
     <div class="designer-review-actions">
       <button class="button button--primary" data-designer-modal-edit>{{lang 'modal.designer_review.edit_button'}}</button>
       <button class="button button--primary" data-designer-modal-continue>{{lang 'modal.designer_review.continue_button'}}</button>

--- a/templates/components/products/product-view-designer.html
+++ b/templates/components/products/product-view-designer.html
@@ -1,6 +1,6 @@
 {{inject 'outOfStockDefaultMessage' (lang 'products.out_of_stock_default_message')}}
-
-<div id="productViewDesigner" class="productView productViewDesigner"
+<div class="container">
+  <div id="productViewDesigner" class="productView productViewDesigner"
     data-event-type="product"
     data-entity-id="{{product.id}}"
     data-name="{{product.title}}"
@@ -30,11 +30,7 @@
         {{/if}}
     {{/each}}
 
-    <div class="productView-image-section">
-        <img src="" 
-             alt="Product Image" 
-             class="productView-large-image"/>
-    </div>
+    <div id="productView-design-image-wrapper"></div>
 
     <section class="productView-details product-options">
         <div class="productView-options">
@@ -77,10 +73,12 @@
         </div>
         {{> components/common/share url=product.url}}
     </section>
+  </div>
+
+  <div id="previewModal" class="modal modal--large" data-reveal>
+      {{> components/common/modal/modal-close-btn }}
+      <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="modal-header-title"></div>
+      <div class="loadingOverlay"></div>
+  </div>
 </div>
 
-<div id="previewModal" class="modal modal--large" data-reveal>
-    {{> components/common/modal/modal-close-btn }}
-    <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="modal-header-title"></div>
-    <div class="loadingOverlay"></div>
-</div>


### PR DESCRIPTION
**Issue:** Using the approach from this [web article](https://dev.to/code_rabbi/programmatically-setting-file-inputs-in-javascript-2p7i) the design image SVG exported by Excalidraw can be automatically set to the product form's file input field. This will eliminate our short term requirements for a BAC backend as the image data will be stored in BigC's backend.

**Resolution:** Updated Excalidraw code to export SVG rather than base64 string. Also updated areas to append SVG to existing HTML parent element so that design images can still be viewed by customer. SVG is now automatically set to input file form field with a unique filename using datetime.
